### PR TITLE
Fix missing paramters in `hkStringPtr::Ctor`

### DIFF
--- a/include/RE/H/hkStringPtr.h
+++ b/include/RE/H/hkStringPtr.h
@@ -28,7 +28,7 @@ namespace RE
 		[[nodiscard]] size_type length() const;
 
 	protected:
-		static void Ctor(const hkStringPtr& a_stringPtr, const char* a_data);
+		static void Ctor(const hkStringPtr& a_stringPtr, const char* a_data, const std::uint32_t a_mask = 0xFFFFFFFF, bool a_mark = true);
 
 		const char* _data;  // 0
 	};

--- a/src/RE/H/hkStringPtr.cpp
+++ b/src/RE/H/hkStringPtr.cpp
@@ -5,11 +5,8 @@ namespace RE
 {
 	hkStringPtr hkStringPtr::Create(const char* a_data)
 	{
-		spdlog::default_logger()->debug("Create init");
 		auto stringPtr = hkStringPtr();
-		spdlog::default_logger()->debug("hkStringPtr() returned");
 		Ctor(stringPtr, a_data);
-		spdlog::default_logger()->debug("Create done");
 		return stringPtr;
 	}
 

--- a/src/RE/H/hkStringPtr.cpp
+++ b/src/RE/H/hkStringPtr.cpp
@@ -5,8 +5,11 @@ namespace RE
 {
 	hkStringPtr hkStringPtr::Create(const char* a_data)
 	{
+		spdlog::default_logger()->debug("Create init");
 		auto stringPtr = hkStringPtr();
+		spdlog::default_logger()->debug("hkStringPtr() returned");
 		Ctor(stringPtr, a_data);
+		spdlog::default_logger()->debug("Create done");
 		return stringPtr;
 	}
 
@@ -37,10 +40,10 @@ namespace RE
 		return size();
 	}
 
-	void hkStringPtr::Ctor(const hkStringPtr& a_stringPtr, const char* a_data)
+	void hkStringPtr::Ctor(const hkStringPtr& a_stringPtr, const char* a_data, const std::uint32_t a_mask, bool a_mark)
 	{
 		using func_t = decltype(&hkStringPtr::Ctor);
 		REL::Relocation<func_t> func{ RELOCATION_ID(56806, 57236) };
-		return func(a_stringPtr, a_data);
+		return func(a_stringPtr, a_data, a_mask, a_mark);
 	}
 }


### PR DESCRIPTION
**Modified:**
- hkStringPtr.h
- hkStringPtr.cpp

**Detail:**
`hkStringPtr::Ctor(const hkStringPtr&, const char*)`
*Changed to:*
`hkStringPtr::Ctor(const hkStringPtr&, const char*, const std::uint32_t a_mask = 0xFFFFFFFF, bool a_mark = true)`